### PR TITLE
Fixed console shortcut script.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='opentmi_client',
       test_suite = 'test',
       entry_points={
           "console_scripts": [
-              "opentmi=opentmi_client:opentmi_client_main",
+              "opentmi=opentmi_client:opentmiclient_main",
           ]
       },
       install_requires=[


### PR DESCRIPTION
The console shortcut script has been pointing to the wrong function name since #4 was merged. This PR should change it to point to the correct location. 