### PR TITLE
Fix for wrong error if suite not found

### DIFF
--- a/opentmi_client/opentmi_client.py
+++ b/opentmi_client/opentmi_client.py
@@ -123,7 +123,7 @@ class OpenTmiClient(object):
             self.logger.warning("exception happened while resolving suite: %s" % (suite))
             return None
         
-        if (campaign_id is None):
+        if campaign_id is None:
             self.logger.warning("could not resolve campaign id for suite: %s" % (suite))
             return None
 
@@ -217,8 +217,6 @@ class OpenTmiClient(object):
         return self.__get_JSON(url)
 
     def __get_suite(self, suite, options=''):
-        suite = suite if isinstance(suite, basestring) else str(suite)
-
         url = self.__url("/campaigns/" + suite + "/suite" + options)
         return self.__get_JSON(url)
 

--- a/opentmi_client/opentmi_client.py
+++ b/opentmi_client/opentmi_client.py
@@ -117,7 +117,13 @@ class OpenTmiClient(object):
     def get_suite(self, suite, options=''):
         """get single suite informations
         """
-        suite = self.__get_suite( self.get_campaign_id(suite), options )
+        campaign_id = self.get_campaign_id(suite)
+
+        if (campaign_id is None or isinstance(campaign_id, Exception)):
+            self.logger.warning("could not resolve campaign id for suite: %s" % (suite))
+            return None
+
+        suite = self.__get_suite(campaign_id, options)
         return suite
 
     # Campaign
@@ -133,6 +139,8 @@ class OpenTmiClient(object):
                 return c['_id']
         except KeyError:
             return KeyError(campaignName)
+        except requests.ConnectionError as err:
+            return err
 
     def get_campaigns(self):
         return self.__get_campaigns()
@@ -210,6 +218,8 @@ class OpenTmiClient(object):
         return self.__get_JSON(url)
 
     def __get_suite(self, suite, options=''):
+        suite = suite if isinstance(suite, basestring) else str(suite)
+
         url = self.__url("/campaigns/" + suite + "/suite" + options)
         return self.__get_JSON(url)
 

--- a/opentmi_client/opentmi_client.py
+++ b/opentmi_client/opentmi_client.py
@@ -117,9 +117,13 @@ class OpenTmiClient(object):
     def get_suite(self, suite, options=''):
         """get single suite informations
         """
-        campaign_id = self.get_campaign_id(suite)
-
-        if (campaign_id is None or isinstance(campaign_id, Exception)):
+        try:
+            campaign_id = self.get_campaign_id(suite)
+        except Exception as err:
+            self.logger.warning("exception happened while resolving suite: %s" % (suite))
+            return None
+        
+        if (campaign_id is None):
             self.logger.warning("could not resolve campaign id for suite: %s" % (suite))
             return None
 
@@ -133,14 +137,9 @@ class OpenTmiClient(object):
         if(isObjectId(campaignName)):
             return campaignName
 
-        try:
-          for c in self.__get_campaigns():
-              if c['name'] == campaignName:
+        for c in self.__get_campaigns():
+            if c['name'] == campaignName:
                 return c['_id']
-        except KeyError:
-            return KeyError(campaignName)
-        except requests.ConnectionError as err:
-            return err
 
     def get_campaigns(self):
         return self.__get_campaigns()

--- a/opentmi_client/tools.py
+++ b/opentmi_client/tools.py
@@ -1,7 +1,7 @@
 import re
 
 def isObjectId(value):
-  if (value is None):
+  if value is None:
     return False
 
   objectidRe = "^[0-9a-fA-F]{24}$"

--- a/opentmi_client/tools.py
+++ b/opentmi_client/tools.py
@@ -1,5 +1,8 @@
 import re
 
 def isObjectId(value):
+  if (value is None):
+    return False
+
   objectidRe = "^[0-9a-fA-F]{24}$"
   return re.match(objectidRe, value)


### PR DESCRIPTION
## Description
This pr fixes reported error case where __get_suite cannot process suite that is None.

## Affected areas
### opentmi_client.py
* __get_suite now attempts to convert non string suites to string before concatenating url
* get_suite now directly returns None if campaign_id is resolved to None
* get_suite now handles errors raised by get_campaign_id and returns None