### PR TITLE
login using env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,12 @@ Test case document schema is available [here](https://github.com/OpenTMI/opentmi
 
 ## Authentication
 
-User have multiple options to authenticate:
+There are multiple options to authenticate:
 * use `Client.login(<username>, <password>)`
 * use `Client.login_with_access_token(<token>, [<service>])`
-  * service are optional and depend on server support
-* Use environment variables (trird automatically when constructor is called):
+  * service are optional and supported values depend on server support.
+   By default `github` is in use.
+* Use environment variables (tries login automatically when constructor is called):
   * Using username and password: `OPENTMI_USERNAME` and `OPENTMI_PASSWORD` or
   * Using github access token: `OPENTMI_GITHUB_ACCESS_TOKEN`
 * use token in host like `http://<token>@localhost`

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Test case document schema is available [here](https://github.com/OpenTMI/opentmi
 
 ## Authentication
 
-Most of API's require authentication and user have multiple options to authenticate:
+User have multiple options to authenticate:
 * use `Client.login(<username>, <password>)`
 * use `Client.login_with_access_token(<token>, [<service>])`
   * service are optional and depend on server support

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Test case document schema is available [here](https://github.com/OpenTMI/opentmi
 
 Most of API's require authentication and user have multiple options to authenticate:
 * use `Client.login(<username>, <password>)`
-* use `Client.login_with_token(<token>, [<service>])`
+* use `Client.login_with_access_token(<token>, [<service>])`
   * service are optional and depend on server support
 * Use environment variables:
   * Using username and password: `OPENTMI_USERNAME` and `OPENTMI_PASSWORD` or

--- a/README.md
+++ b/README.md
@@ -18,17 +18,29 @@ See the [Developers Guide](development.md) if you want to develop this library.
 Library provides Command line Interface to communicate with OpenTMI -backend
 
 ```
-/> opentmi --help
-usage: opentmi [-h] [--version VERSION] [--host HOST] [-p PORT] [--list LIST]
-               [--testcases TESTCASES]
+$ opentmi --help
+usage: opentmi [-h] [-v] [-s] [--host HOST] [--user USER]
+               [--password PASSWORD] [--token TOKEN]
+               [--token_service TOKEN_SERVICE] [-p PORT]
+               <subcommand> ...
 
 optional arguments:
   -h, --help            show this help message and exit
-  --version VERSION     Prints package version and exits
+  -v                    verbose level... repeat up to three times.
+  -s, --silent          Silent - only errors will be printed
   --host HOST           OpenTMI host, default: localhost
+  --user USER           username
+  --password PASSWORD   password
+  --token TOKEN         Authentication token
+  --token_service TOKEN_SERVICE
+                        Optional authentication service
   -p PORT, --port PORT  OpenTMI port
-  --list LIST           List something
-  --testcases TESTCASES
+
+subcommand:
+  <subcommand>          sub-command help
+    version             Display version information
+    list                List something
+    store               Create something
 ```
 
 example:
@@ -76,9 +88,16 @@ Test case document schema is available [here](https://github.com/OpenTMI/opentmi
 * `tcid` -field have to be unique for each test cases.
 * There is couple mandatory fields by default: `tcid` and `exec.verdict`. Allowed values for result verdict is: `pass`, `fail`, `inconclusive`, `blocked` and `error`. `upload_results()` -function also create test case document if it doesn't exists in database.
 
-For authentication you can use optionally environment variables:
-Using username and password: `OPENTMI_USERNAME` and `OPENTMI_PASSWORD` or
-Using github access token: `OPENTMI_GITHUB_ACCESS_TOKEN`.
+## Authentication
+
+Most of API's require authentication and user have multiple options to authenticate:
+* use `Client.login(<username>, <password>)`
+* use `Client.login_with_token(<token>, [<service>])`
+  * service are optional and depend on server support
+* Use environment variables:
+  * Using username and password: `OPENTMI_USERNAME` and `OPENTMI_PASSWORD` or
+  * Using github access token: `OPENTMI_GITHUB_ACCESS_TOKEN`
+* use token in host like `http://<token>@localhost`
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Test case document schema is available [here](https://github.com/OpenTMI/opentmi
 * `tcid` -field have to be unique for each test cases.
 * There is couple mandatory fields by default: `tcid` and `exec.verdict`. Allowed values for result verdict is: `pass`, `fail`, `inconclusive`, `blocked` and `error`. `upload_results()` -function also create test case document if it doesn't exists in database.
 
+For authentication you can use optionally environment variables:
+Using username and password: `OPENTMI_USERNAME` and `OPENTMI_PASSWORD` or
+Using github access token: `OPENTMI_GITHUB_ACCESS_TOKEN`.
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Most of API's require authentication and user have multiple options to authentic
 * use `Client.login(<username>, <password>)`
 * use `Client.login_with_access_token(<token>, [<service>])`
   * service are optional and depend on server support
-* Use environment variables:
+* Use environment variables (trird automatically when constructor is called):
   * Using username and password: `OPENTMI_USERNAME` and `OPENTMI_PASSWORD` or
   * Using github access token: `OPENTMI_GITHUB_ACCESS_TOKEN`
 * use token in host like `http://<token>@localhost`

--- a/opentmi_client/api/client.py
+++ b/opentmi_client/api/client.py
@@ -303,7 +303,8 @@ class OpenTmiClient(object):
         """
         function to check if login is done.
         If not try to use environment variables by default
-        :param raise_if_fail: Boolean, raise if login failed or env variabels are does not exists. Default False
+        :param raise_if_fail: Boolean, raise if login failed
+        or env variables are does not exists. Default False
         :return: OpenTmiClient
         :throws: OpentmiException in case of failure
         """
@@ -319,6 +320,7 @@ class OpenTmiClient(object):
             return self.login(username, password)
         if raise_if_fail:
             raise OpentmiException("login required")
+        return self
 
     # Private members
 

--- a/opentmi_client/api/client.py
+++ b/opentmi_client/api/client.py
@@ -56,8 +56,7 @@ class OpenTmiClient(object):
         self.__logger = get_logger()
         self.__result_converter = None
         self.__tc_converter = None
-        self.__transport = Transport(host, port) if not transport else transport
-        if token: self.__transport.set_token(token)
+        self.__transport = Transport(host, port, token) if not transport else transport
 
     def set_result_converter(self, fn):
         """

--- a/opentmi_client/api/client.py
+++ b/opentmi_client/api/client.py
@@ -17,7 +17,7 @@ ENV_OPENTMI_USERNAME = "OPENTMI_USERNAME"
 ENV_OPENTMI_PASSWORD = "OPENTMI_PASSWORD"
 
 
-#pylint: disable-msg=too-many-arguments
+# pylint: disable-msg=too-many-arguments
 def create(host='localhost', port=None, result_converter=None, testcase_converter=None):
     """
     Generic create -api for Client
@@ -44,22 +44,17 @@ class OpenTmiClient(object):
     def __init__(self,
                  host='127.0.0.1',
                  port=None,
-                 token=None,
                  transport=None):
         """
         Constructor for OpenTMI client
         :param host: opentmi host address (default="localhost")
         :param port: opentmi server port (default=3000)
-        :param result_converter:
-        :param testcase_converter: function
         :param transport: optional Transport layer. Mostly for testing purpose
         """
         self.__logger = get_logger()
         self.__result_converter = None
         self.__tc_converter = None
-        self.__transport = Transport(host, port, token) if not transport else transport
-        if transport and token:
-            transport.set_token(token)
+        self.__transport = Transport(host, port) if not transport else transport
 
     def set_result_converter(self, func):
         """
@@ -88,7 +83,7 @@ class OpenTmiClient(object):
             "email": username,
             "password": password
         }
-        url = self.__transport.host + "/auth/login"
+        url = self.__resolve_url("/auth/login")
         response = self.__transport.post_json(url, payload)
         token = response.get("token")
         self.logger.info("Login success. Token: %s", token)
@@ -161,7 +156,7 @@ class OpenTmiClient(object):
         """
         return self.__version
 
-    @requires_logged_in
+    # @requires_logged_in
     def upload_build(self, build):
         """
         Upload build
@@ -181,7 +176,7 @@ class OpenTmiClient(object):
         return None
 
     # Suite
-    @requires_logged_in
+    # @requires_logged_in
     def get_suite(self, suite, options=''):
         """
         get single suite informations
@@ -205,7 +200,7 @@ class OpenTmiClient(object):
         return suite
 
     # Campaign
-    @requires_logged_in
+    # @requires_logged_in
     def get_campaign_id(self, campaign_name):
         """
         get campaign id from name
@@ -220,7 +215,7 @@ class OpenTmiClient(object):
                 return campaign['_id']
         return None
 
-    @requires_logged_in
+    # @requires_logged_in
     def get_campaigns(self):
         """
         Get campaigns
@@ -228,7 +223,7 @@ class OpenTmiClient(object):
         """
         return self.__get_campaigns()
 
-    @requires_logged_in
+    # @requires_logged_in
     def get_campaign_names(self):
         """
         Get campaign names
@@ -240,7 +235,7 @@ class OpenTmiClient(object):
             campaign_names.append(campaign['name'])
         return campaign_names
 
-    @requires_logged_in
+    # @requires_logged_in
     def get_testcases(self, filters=None):
         """
         Get testcases
@@ -249,7 +244,7 @@ class OpenTmiClient(object):
         """
         return self.__get_testcases(filters)
 
-    @requires_logged_in
+    # @requires_logged_in
     def update_testcase(self, metadata):
         """
         update test case
@@ -266,7 +261,7 @@ class OpenTmiClient(object):
             self.__create_testcase(metadata)
         return self
 
-    @requires_logged_in
+    # @requires_logged_in
     def upload_results(self, result):
         """
         Upload result
@@ -308,13 +303,11 @@ class OpenTmiClient(object):
         :return: OpenTmiClient
         :throws: OpentmiException in case of failure
         """
-        if self.is_logged_in:
-            return self
         # use environment variables if available
         token = os.getenv(ENV_GITHUB_ACCESS_TOKEN)
         if token:
             self.logger.info("Using github access token from environment variable")
-            return self.login_with_token(token=token, service="github")
+            return self.login_with_access_token(access_token=token, service="github")
         username = os.getenv(ENV_OPENTMI_USERNAME)
         password = os.getenv(ENV_OPENTMI_PASSWORD)
         if username and password:

--- a/opentmi_client/api/client.py
+++ b/opentmi_client/api/client.py
@@ -6,7 +6,8 @@ import os
 
 
 # Application modules
-from opentmi_client.utils import is_object_id, get_logger, requires_logged_in
+from opentmi_client.utils import is_object_id, get_logger
+# from opentmi_client.utils import requires_logged_in
 from opentmi_client.utils import OpentmiException, TransportException
 from opentmi_client.transport import Transport
 
@@ -101,6 +102,7 @@ class OpenTmiClient(object):
             "access_token": access_token
         }
         url = "{}/auth/{}/token".format(self.__transport.host, service)
+        self.logger.debug("Login using %s token", service)
         response = self.__transport.post_json(url, payload)
         token = response.get("token")
         self.logger.info("Login success. Token: %s", token)

--- a/opentmi_client/api/client.py
+++ b/opentmi_client/api/client.py
@@ -30,7 +30,7 @@ def create(host='localhost', port=None, result_converter=None, testcase_converte
     """
     client = OpenTmiClient(host, port)
     client.set_result_converter(result_converter)
-    client.set_tc_converted(testcase_converter)
+    client.set_tc_converter(testcase_converter)
     return client
 
 
@@ -56,6 +56,7 @@ class OpenTmiClient(object):
         self.__result_converter = None
         self.__tc_converter = None
         self.__transport = Transport(host, port) if not transport else transport
+        self.try_login()
 
     def set_result_converter(self, func):
         """
@@ -65,7 +66,7 @@ class OpenTmiClient(object):
         """
         self.__result_converter = func
 
-    def set_tc_converted(self, func):
+    def set_tc_converter(self, func):
         """
         Set custom test case converter
         :param func: conversion function
@@ -298,10 +299,11 @@ class OpenTmiClient(object):
             self.logger.warning(error)
         return None
 
-    def try_login(self):
+    def try_login(self, raise_if_fail=False):
         """
         function to check if login is done.
         If not try to use environment variables by default
+        :param raise_if_fail: Boolean, raise if login failed or env variabels are does not exists. Default False
         :return: OpenTmiClient
         :throws: OpentmiException in case of failure
         """
@@ -315,7 +317,8 @@ class OpenTmiClient(object):
         if username and password:
             self.logger.info("Using opentmi credentials from environment variable")
             return self.login(username, password)
-        raise OpentmiException("login required")
+        if raise_if_fail:
+            raise OpentmiException("login required")
 
     # Private members
 

--- a/opentmi_client/api/client.py
+++ b/opentmi_client/api/client.py
@@ -6,7 +6,8 @@ import os
 
 
 # Application modules
-from opentmi_client.utils import is_object_id, get_logger, OpentmiException, TransportException, requires_logged_in
+from opentmi_client.utils import is_object_id, get_logger, requires_logged_in
+from opentmi_client.utils import OpentmiException, TransportException
 from opentmi_client.transport import Transport
 
 REQUEST_TIMEOUT = 30
@@ -27,8 +28,8 @@ def create(host='localhost', port=None, result_converter=None, testcase_converte
     :return: OpenTmiClient
     """
     client = OpenTmiClient(host, port)
-    client.set_result_converter = result_converter
-    client.set_testcase_converter = testcase_converter
+    client.set_result_converter(result_converter)
+    client.set_tc_converted(testcase_converter)
     return client
 
 
@@ -60,21 +61,21 @@ class OpenTmiClient(object):
         if transport and token:
             transport.set_token(token)
 
-    def set_result_converter(self, fn):
+    def set_result_converter(self, func):
         """
         Set custom result converter
-        :param fn: conversion function
+        :param func: conversion function
         :return: None
         """
-        self.__result_converter = fn
+        self.__result_converter = func
 
-    def set_tc_converted(self, fn):
+    def set_tc_converted(self, func):
         """
         Set custom test case converter
-        :param fn: conversion function
+        :param func: conversion function
         :return: None
         """
-        self.__tc_converter = fn
+        self.__tc_converter = func
 
     def login(self, username, password):
         """
@@ -302,9 +303,7 @@ class OpenTmiClient(object):
             self.logger.warning(error)
         return None
 
-    # Private members
-
-    def _try_login(self):
+    def try_login(self):
         """
         function to check if login is done.
         If not try to use environment variables by default
@@ -324,6 +323,8 @@ class OpenTmiClient(object):
             self.logger.info("Using opentmi credentials from environment variable")
             return self.login(username, password)
         raise OpentmiException("login required")
+
+    # Private members
 
     def __get_testcases(self, filters=None):
         url = self.__resolve_apiuri("/testcases")

--- a/opentmi_client/cli/main.py
+++ b/opentmi_client/cli/main.py
@@ -249,7 +249,8 @@ class OpentTMIClientCLI(object):
 
         raise NotImplementedError('store')
 
-    def create_client(self, args):
+    @staticmethod
+    def create_client(args):
         """
         Create OpenTmiClient instance based on args
         :param args: arguments
@@ -271,7 +272,7 @@ class OpentTMIClientCLI(object):
         :param args:
         :return:
         """
-        client = self.create_client(args)
+        client = OpentTMIClientCLI.create_client(args)
         client.upload_build(args.file)
         return EXIT_CODE_SUCCESS
 
@@ -281,10 +282,9 @@ class OpentTMIClientCLI(object):
         :param args:
         :return:
         """
-        client = self.create_client(args)
+        client = OpentTMIClientCLI.create_client(args)
         client.update_testcase(args.file)
         return EXIT_CODE_SUCCESS
-
 
     def subcmd_store_result(self, args):
         """
@@ -292,7 +292,7 @@ class OpentTMIClientCLI(object):
         :param args:
         :return:
         """
-        client = self.create_client(args)
+        client = OpentTMIClientCLI.create_client(args)
         client.upload_results(args.file)
         return EXIT_CODE_SUCCESS
 
@@ -301,7 +301,7 @@ class OpentTMIClientCLI(object):
         :param args:
         :return:
         """
-        client = self.create_client(args)
+        client = OpentTMIClientCLI.create_client(args)
         if args.testcases:
             testcases = client.get_testcases()
             if args.json:
@@ -319,6 +319,7 @@ class OpentTMIClientCLI(object):
                     print(campaign)
         return 0
 
+
 def opentmiclient_main():
     """
     Function used to drive CLI (command line interface) application.
@@ -332,6 +333,7 @@ def opentmiclient_main():
     except OpentmiException as error:
         print(str(error))
         sys.exit(EXIT_CODE_OPERATION_FAILED)
+
 
 if __name__ == '__main__':
     opentmiclient_main()

--- a/opentmi_client/cli/main.py
+++ b/opentmi_client/cli/main.py
@@ -249,8 +249,7 @@ class OpentTMIClientCLI(object):
 
         raise NotImplementedError('store')
 
-    @staticmethod
-    def create_client(args):
+    def create_client(self, args):
         """
         Create OpenTmiClient instance based on args
         :param args: arguments
@@ -259,10 +258,12 @@ class OpentTMIClientCLI(object):
         client = OpenTmiClient(host=args.host, port=args.port, token=args.token)
         if args.user:
             if args.password:
+                self.logger.debug("Use credentials from env variable")
                 client.login(args.user, args.password)
             else:
                 raise OpentmiException("password missing")
         elif args.token:
+            self.logger.debug("Use token from env variable")
             client.login_with_token(args.token, args.token_service)
         return client
 
@@ -272,7 +273,7 @@ class OpentTMIClientCLI(object):
         :param args:
         :return:
         """
-        client = OpentTMIClientCLI.create_client(args)
+        client = self.create_client(args)
         client.upload_build(args.file)
         return EXIT_CODE_SUCCESS
 
@@ -282,7 +283,7 @@ class OpentTMIClientCLI(object):
         :param args:
         :return:
         """
-        client = OpentTMIClientCLI.create_client(args)
+        client = self.create_client(args)
         client.update_testcase(args.file)
         return EXIT_CODE_SUCCESS
 
@@ -292,7 +293,7 @@ class OpentTMIClientCLI(object):
         :param args:
         :return:
         """
-        client = OpentTMIClientCLI.create_client(args)
+        client = self.create_client(args)
         client.upload_results(args.file)
         return EXIT_CODE_SUCCESS
 
@@ -301,7 +302,7 @@ class OpentTMIClientCLI(object):
         :param args:
         :return:
         """
-        client = OpentTMIClientCLI.create_client(args)
+        client = self.create_client(args)
         if args.testcases:
             testcases = client.get_testcases()
             if args.json:

--- a/opentmi_client/cli/main.py
+++ b/opentmi_client/cli/main.py
@@ -249,7 +249,8 @@ class OpentTMIClientCLI(object):
 
         raise NotImplementedError('store')
 
-    def create_client(self, args):
+    @staticmethod
+    def create_client(args):
         """
         Create OpenTmiClient instance based on args
         :param args: arguments

--- a/opentmi_client/cli/main.py
+++ b/opentmi_client/cli/main.py
@@ -102,6 +102,11 @@ class OpentTMIClientCLI(object):
                             default='password',
                             help='password')
 
+        parser.add_argument('--token',
+                            dest='token',
+                            default=None,
+                            help='Authentication token')
+
         parser.add_argument('-p', '--port',
                             dest='port',
                             type=int,

--- a/opentmi_client/cli/main.py
+++ b/opentmi_client/cli/main.py
@@ -258,12 +258,10 @@ class OpentTMIClientCLI(object):
         client = OpenTmiClient(host=args.host, port=args.port)
         if args.user:
             if args.password:
-                self.logger.debug("Use credentials from env variable")
                 client.login(args.user, args.password)
             else:
                 raise OpentmiException("password missing")
         elif args.token:
-            self.logger.debug("Use token from env variable")
             service = args.token_service or "github"
             client.login_with_access_token(args.token, service)
         return client

--- a/opentmi_client/cli/main.py
+++ b/opentmi_client/cli/main.py
@@ -255,7 +255,7 @@ class OpentTMIClientCLI(object):
         :param args: arguments
         :return: OpenTmiClient instance
         """
-        client = OpenTmiClient(host=args.host, port=args.port, token=args.token)
+        client = OpenTmiClient(host=args.host, port=args.port)
         if args.user:
             if args.password:
                 self.logger.debug("Use credentials from env variable")
@@ -264,7 +264,8 @@ class OpentTMIClientCLI(object):
                 raise OpentmiException("password missing")
         elif args.token:
             self.logger.debug("Use token from env variable")
-            client.login_with_token(args.token, args.token_service)
+            service = args.token_service or "github"
+            client.login_with_access_token(args.token, service)
         return client
 
     def subcmd_store_build(self, args):

--- a/opentmi_client/transport/transport.py
+++ b/opentmi_client/transport/transport.py
@@ -27,8 +27,9 @@ class Transport(object):
     def __init__(self, host="127.0.0.1", port=None, token=None):
         """
         Constructor for Transport
-        :param host:
-        :param port:
+        :param host: Hostname as a String
+        :param port: optional port as a positive Integer
+        :param token: optional token
         """
         self.logger = get_logger()
         self.__token = None
@@ -78,6 +79,10 @@ class Transport(object):
         return self
 
     def has_token(self):
+        """
+        Check if token is available
+        :return: Boolean True if token exists, otherwise False
+        """
         return self.__token != None
 
     def get_url(self, path):

--- a/opentmi_client/transport/transport.py
+++ b/opentmi_client/transport/transport.py
@@ -62,6 +62,9 @@ class Transport(object):
         self.__token = token
         return self
 
+    def has_token(self):
+        return self.__token != None
+
     @property
     def __headers(self):
         headers = {

--- a/opentmi_client/transport/transport.py
+++ b/opentmi_client/transport/transport.py
@@ -31,8 +31,11 @@ class Transport(object):
         :param port:
         """
         self.logger = get_logger()
-        self.__token = token
+        self.__token = None
         self.__host = None
+        if token:
+            self.set_token(token)
+
         self.set_host(host, port)
         self.logger.info("OpenTMI host: %s", self.host)
 
@@ -41,10 +44,13 @@ class Transport(object):
         Set host address and port
         :param host:
         :param port:
-        :return:
+        :return: None
         """
         self.__host = resolve_host(host, port)
-        self.__token = resolve_token(host)
+        token = resolve_token(host)
+        if token:
+            self.__host = self.__host.replace(token + "@", "")
+            self.set_token(token)
 
     @property
     def host(self):
@@ -73,6 +79,14 @@ class Transport(object):
 
     def has_token(self):
         return self.__token != None
+
+    def get_url(self, path):
+        """
+        Create url from path
+        :param path: string, e.g. "/auth/login"
+        :return: url as a string
+        """
+        return self.__host + path
 
     @property
     def __headers(self):

--- a/opentmi_client/transport/transport.py
+++ b/opentmi_client/transport/transport.py
@@ -83,7 +83,7 @@ class Transport(object):
         Check if token is available
         :return: Boolean True if token exists, otherwise False
         """
-        return self.__token != None
+        return self.__token is not None
 
     def get_url(self, path):
         """

--- a/opentmi_client/transport/transport.py
+++ b/opentmi_client/transport/transport.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     # python3
     from urllib.parse import urlencode, quote
-from opentmi_client.utils import get_logger, resolve_host, TransportException
+from opentmi_client.utils import get_logger, resolve_host, resolve_token, TransportException
 
 REQUEST_TIMEOUT = 30
 NOT_FOUND = 404
@@ -24,19 +24,19 @@ class Transport(object):
 
     __request_timeout = 10
 
-    def __init__(self, host="127.0.0.1", port=None):
+    def __init__(self, host="127.0.0.1", port=None, token=None):
         """
         Constructor for Transport
         :param host:
         :param port:
         """
         self.logger = get_logger()
-        self.__token = None
+        self.__token = token
         self.__host = None
         self.set_host(host, port)
         self.logger.info("OpenTMI host: %s", self.host)
 
-    def set_host(self, host, port):
+    def set_host(self, host, port=None):
         """
         Set host address and port
         :param host:
@@ -44,6 +44,7 @@ class Transport(object):
         :return:
         """
         self.__host = resolve_host(host, port)
+        self.__token = resolve_token(host)
 
     @property
     def host(self):
@@ -52,6 +53,14 @@ class Transport(object):
         :return: host as a string
         """
         return self.__host
+
+    @property
+    def token(self):
+        """
+        Getter for token
+        :return: token as a string or None
+        """
+        return self.__token
 
     def set_token(self, token):
         """

--- a/opentmi_client/utils/__init__.py
+++ b/opentmi_client/utils/__init__.py
@@ -1,7 +1,7 @@
 """
 Collect all utils API's
 """
-from opentmi_client.utils.tools import is_object_id, resolve_host, archive_files
+from opentmi_client.utils.tools import is_object_id, resolve_host, archive_files, requires_logged_in
 from opentmi_client.utils.logger import get_logger
 from opentmi_client.utils.exceptions import OpentmiException
 from opentmi_client.utils.exceptions import TransportException

--- a/opentmi_client/utils/__init__.py
+++ b/opentmi_client/utils/__init__.py
@@ -1,7 +1,7 @@
 """
 Collect all utils API's
 """
-from opentmi_client.utils.tools import is_object_id, resolve_host, archive_files, requires_logged_in
+from opentmi_client.utils.tools import is_object_id, resolve_host, resolve_token, archive_files, requires_logged_in
 from opentmi_client.utils.logger import get_logger
 from opentmi_client.utils.exceptions import OpentmiException
 from opentmi_client.utils.exceptions import TransportException

--- a/opentmi_client/utils/__init__.py
+++ b/opentmi_client/utils/__init__.py
@@ -1,7 +1,10 @@
 """
 Collect all utils API's
 """
-from opentmi_client.utils.tools import is_object_id, resolve_host, resolve_token, archive_files, requires_logged_in
+from opentmi_client.utils.tools import is_object_id
+from opentmi_client.utils.tools import resolve_host, resolve_token
+from opentmi_client.utils.tools import archive_files
+from opentmi_client.utils.tools import requires_logged_in
 from opentmi_client.utils.logger import get_logger
 from opentmi_client.utils.exceptions import OpentmiException
 from opentmi_client.utils.exceptions import TransportException

--- a/opentmi_client/utils/tools.py
+++ b/opentmi_client/utils/tools.py
@@ -6,8 +6,6 @@ import zipfile
 import os
 import six
 
-from opentmi_client.utils.exceptions import OpentmiException
-
 
 def is_object_id(value):
     """
@@ -61,7 +59,7 @@ def archive_files(files, zip_filename, base_path=""):
     zip_file.close()
     return zip_filename
 
-def requires_logged_in(fn):
+def requires_logged_in(func):
     """
     Decorator which verify that client are logged in
     if not but env variables are available
@@ -70,7 +68,12 @@ def requires_logged_in(fn):
     :return: wrapper function
     """
     def ret_fn(*args):
+        """
+        wrapper function
+        :param args: argument for decorated function
+        :return: return decorated function return values
+        """
         self = args[0]
-        self._try_login()
-        return fn(*args)
+        self.try_login()
+        return func(*args)
     return ret_fn

--- a/opentmi_client/utils/tools.py
+++ b/opentmi_client/utils/tools.py
@@ -75,6 +75,6 @@ def requires_logged_in(func):
         """
         self = args[0]
         if not self.is_logged_in:
-            self.try_login()
+            self.try_login(raise_if_fail=True)
         return func(*args)
     return ret_fn

--- a/opentmi_client/utils/tools.py
+++ b/opentmi_client/utils/tools.py
@@ -6,6 +6,8 @@ import zipfile
 import os
 import six
 
+from opentmi_client.utils.exceptions import OpentmiException
+
 
 def is_object_id(value):
     """
@@ -47,3 +49,17 @@ def archive_files(files, zip_filename, base_path=""):
         zip_file.write(os.path.join(base_path, filename), filename)
     zip_file.close()
     return zip_filename
+
+def requires_logged_in(fn):
+    """
+    Decorator which verify that client are logged in
+    if not but env variables are available
+    it tries to loggin using them
+    :param fn: function to decorated
+    :return: wrapper function
+    """
+    def ret_fn(*args):
+        self = args[0]
+        self._try_login()
+        return fn(*args)
+    return ret_fn

--- a/opentmi_client/utils/tools.py
+++ b/opentmi_client/utils/tools.py
@@ -74,6 +74,7 @@ def requires_logged_in(func):
         :return: return decorated function return values
         """
         self = args[0]
-        self.try_login()
+        if not self.is_logged_in:
+            self.try_login()
         return func(*args)
     return ret_fn

--- a/opentmi_client/utils/tools.py
+++ b/opentmi_client/utils/tools.py
@@ -34,10 +34,6 @@ def resolve_host(host, port=None):
         host += ":" + str(port)
     if not host.startswith("http"):
         host = "http://" + host
-    token = resolve_token(host)
-    if token:
-        # remove token from host url
-        host = host.replace(token+"@", "")
     return host
 
 def resolve_token(host):

--- a/opentmi_client/utils/tools.py
+++ b/opentmi_client/utils/tools.py
@@ -34,7 +34,22 @@ def resolve_host(host, port=None):
         host += ":" + str(port)
     if not host.startswith("http"):
         host = "http://" + host
+    token = resolve_token(host)
+    if token:
+        # remove token from host url
+        host = host.replace(token+"@", "")
     return host
+
+def resolve_token(host):
+    """
+    Resolve access token from host string
+    Format: https://<token>@<url>
+    :param host: host as a string
+    :return: token or None
+    """
+    host_re = r"^https?://([a-zA-Z0-9\-_]+?\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+)\@.+$"
+    match = re.match(host_re, host)
+    return match.group(1) if match else None
 
 def archive_files(files, zip_filename, base_path=""):
     """

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -79,23 +79,25 @@ class TestClient(unittest.TestCase):
         client = Client()
         self.assertEqual(client.get_version(), 0)
 
-    def test_try_login_raise(self):
+    def test_try_login_raise_when_required(self):
         client = Client()
         with self.assertRaises(OpentmiException):
-            client.try_login()
+            client.try_login(raise_if_fail=True)
+
+    def test_try_login_not_raise_by_default(self):
+        client = Client()
+        client.try_login()
 
     @mock.patch.dict(os.environ, {'OPENTMI_GITHUB_ACCESS_TOKEN': 'a.b.c'})
     @patch('opentmi_client.transport.Transport.post_json', side_effect=mocked_post)
     def test_try_login_token(self,  mock_post):
         client = Client()
-        client.try_login()
         mock_post.assert_called_once_with("http://127.0.0.1/auth/github/token", {"token": "a.b.c"})
 
     @mock.patch.dict(os.environ, {'OPENTMI_USERNAME': 'username', "OPENTMI_PASSWORD": "passw"})
     @patch('opentmi_client.transport.Transport.post_json', side_effect=mocked_post)
     def test_try_login_token(self, mock_post):
         client = Client()
-        client.try_login()
         mock_post.assert_called_once_with("http://127.0.0.1/auth/login", {"email": "username", "password": "passw"})
 
     @patch('opentmi_client.transport.Transport.post_json', side_effect=mocked_post)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import unittest
 from mock import MagicMock, patch, call
 from opentmi_client.api import Client, create

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -62,8 +62,16 @@ class TestClient(unittest.TestCase):
         mock_transport(tr_mock)
         client = Client(transport=tr_mock)
         client.login("user", "passwd")
-        tr_mock.post_json.assert_called_once_with("http://127.0.0.1/login",
+        tr_mock.post_json.assert_called_once_with("http://127.0.0.1/auth/login",
                                                   {"username": "user", "password": "passwd"})
+
+    def test_login_with_github_token(self):
+        tr_mock = Transport()
+        mock_transport(tr_mock)
+        client = Client(transport=tr_mock)
+        client.login_with_token("a.b.c", "github")
+        tr_mock.post_json.assert_called_once_with("http://127.0.0.1/auth/login/github/token",
+                                                  {"token": "a.b.c"})
 
     def test_logout(self):
         tr_mock = Transport()

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,5 +1,5 @@
 import unittest
-from mock import MagicMock, patch, call, PropertyMock
+from mock import MagicMock, patch, call
 from opentmi_client.api import Client, create
 from opentmi_client.utils import TransportException, OpentmiException
 from opentmi_client.transport.transport import Transport
@@ -63,14 +63,14 @@ class TestClient(unittest.TestCase):
         client = Client(transport=tr_mock)
         client.login("user", "passwd")
         tr_mock.post_json.assert_called_once_with("http://127.0.0.1/auth/login",
-                                                  {"username": "user", "password": "passwd"})
+                                                  {"email": "user", "password": "passwd"})
 
     def test_login_with_github_token(self):
         tr_mock = Transport()
         mock_transport(tr_mock)
         client = Client(transport=tr_mock)
         client.login_with_token("a.b.c", "github")
-        tr_mock.post_json.assert_called_once_with("http://127.0.0.1/auth/login/github/token",
+        tr_mock.post_json.assert_called_once_with("http://127.0.0.1/auth/github/token",
                                                   {"token": "a.b.c"})
 
     def test_logout(self):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -50,9 +50,14 @@ class TestClient(unittest.TestCase):
     def test_token(self):
         tr_mock = Transport()
         mock_transport(tr_mock)
+        tr_mock.has_token = MagicMock()
+        def has_token(*args):
+            return True
+        tr_mock.has_token.return_value = True
         client = Client(transport=tr_mock)
         client.set_token(DUMMY_TOKEN)
         tr_mock.set_token.assert_called_once_with(DUMMY_TOKEN)
+        self.assertEqual(client.is_logged_in, True)
 
     def test_login(self):
         tr_mock = Transport()
@@ -68,6 +73,7 @@ class TestClient(unittest.TestCase):
         client.login_with_access_token("token", "github")
         tr_mock.post_json.assert_called_once_with("http://127.0.0.1/auth/github/token",
                                                   {"access_token": "token"})
+
     def test_logout(self):
         tr_mock = Transport()
         mock_transport(tr_mock)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -7,7 +7,8 @@ from opentmi_client.cli.main import opentmiclient_main, OpentTMIClientCLI
 def mocked_get_list(*args, **kwargs):
     return [{"tcid": "b", "name": "c"}]
 
-FAKE_TOKEN = "abc"
+FAKE_TOKEN = "a.b.c"
+
 
 class TestCli(unittest.TestCase):
     @patch('sys.stdout', new_callable=Mock())

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import unittest
 from mock import patch, Mock
 from opentmi_client.cli.main import opentmiclient_main, OpentTMIClientCLI

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -5,9 +5,6 @@ from mock import patch, Mock
 from opentmi_client.cli.main import opentmiclient_main, OpentTMIClientCLI
 
 
-def mocked_get_list(*args, **kwargs):
-    return [{"tcid": "b", "name": "c"}]
-
 FAKE_TOKEN = "a.b.c"
 
 
@@ -56,37 +53,41 @@ class TestCli(unittest.TestCase):
         with patch('sys.argv', fake_args):
             cli = OpentTMIClientCLI()
 
-    @patch('opentmi_client.transport.Transport.get_json', side_effect=mocked_get_list)
+    @patch('opentmi_client.transport.Transport.get_json', returns=[{"tcid": "b", "name": "c"}])
+    @patch('opentmi_client.transport.Transport.post_json', returns={"token": "a.b.c"})
     @patch('sys.stdout', new_callable=Mock())
     @patch("sys.exit")
-    def test_list_testcases(self, mock_exit, _mock_stdout, mock_list):
+    def test_list_testcases(self, mock_exit, _mock_stdout, mock_list, mock_token):
         fake_args = ["opentmi", "--token", FAKE_TOKEN, "list", "--testcases"]
         with patch('sys.argv', fake_args):
             opentmiclient_main()
         mock_exit.assert_called_with(0)
 
-    @patch('opentmi_client.transport.Transport.get_json', side_effect=mocked_get_list)
+    @patch('opentmi_client.transport.Transport.get_json', returns=[{"tcid": "b", "name": "c"}])
+    @patch('opentmi_client.transport.Transport.post_json', returns={"token": "a.b.c"})
     @patch('sys.stdout', new_callable=Mock())
     @patch("sys.exit")
-    def test_list_results(self, mock_exit, _mock_stdout, mock_list):
+    def test_list_campaigns(self, mock_exit, _mock_stdout, mock_token, mock_list):
         fake_args = ["opentmi", "--token", FAKE_TOKEN, "list", "--campaigns"]
         with patch('sys.argv', fake_args):
             opentmiclient_main()
         mock_exit.assert_called_with(0)
 
-    @patch('opentmi_client.transport.Transport.get_json', side_effect=mocked_get_list)
+    @patch('opentmi_client.transport.Transport.get_json', returns=[{"tcid": "b", "name": "c"}])
+    @patch('opentmi_client.transport.Transport.post_json', returns={"token": "a.b.c"})
     @patch('sys.stdout', new_callable=Mock())
     @patch("sys.exit")
-    def test_list_testcases_json(self, mock_exit, _mock_stdout, mock_list):
+    def test_list_results_json(self, mock_exit, _mock_stdout, mock_token, mock_list):
         fake_args = ["opentmi", "--token", FAKE_TOKEN, "list", "--testcases", "--json"]
         with patch('sys.argv', fake_args):
             opentmiclient_main()
         mock_exit.assert_called_with(0)
 
-    @patch('opentmi_client.transport.Transport.get_json', side_effect=mocked_get_list)
+    @patch('opentmi_client.transport.Transport.get_json', returns=[{"tcid": "b", "name": "c"}])
+    @patch('opentmi_client.transport.Transport.post_json', returns={"token": "a.b.c"})
     @patch('sys.stdout', new_callable=Mock())
     @patch("sys.exit")
-    def test_list_results_json(self, mock_exit, _mock_stdout, mock_list):
+    def test_list_results_json(self, mock_exit, _mock_stdout, mock_token, mock_list):
         fake_args = ["opentmi", "--token", FAKE_TOKEN, "list", "--campaigns", "--json"]
         with patch('sys.argv', fake_args):
             opentmiclient_main()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -7,6 +7,7 @@ from opentmi_client.cli.main import opentmiclient_main, OpentTMIClientCLI
 def mocked_get_list(*args, **kwargs):
     return [{"tcid": "b", "name": "c"}]
 
+FAKE_TOKEN = "abc"
 
 class TestCli(unittest.TestCase):
     @patch('sys.stdout', new_callable=Mock())
@@ -57,7 +58,7 @@ class TestCli(unittest.TestCase):
     @patch('sys.stdout', new_callable=Mock())
     @patch("sys.exit")
     def test_list_testcases(self, mock_exit, _mock_stdout, mock_list):
-        fake_args = ["opentmi", "list", "--testcases"]
+        fake_args = ["opentmi", "--token", FAKE_TOKEN, "list", "--testcases"]
         with patch('sys.argv', fake_args):
             opentmiclient_main()
         mock_exit.assert_called_with(0)
@@ -66,7 +67,7 @@ class TestCli(unittest.TestCase):
     @patch('sys.stdout', new_callable=Mock())
     @patch("sys.exit")
     def test_list_results(self, mock_exit, _mock_stdout, mock_list):
-        fake_args = ["opentmi", "list", "--campaigns"]
+        fake_args = ["opentmi", "--token", FAKE_TOKEN, "list", "--campaigns"]
         with patch('sys.argv', fake_args):
             opentmiclient_main()
         mock_exit.assert_called_with(0)
@@ -75,7 +76,7 @@ class TestCli(unittest.TestCase):
     @patch('sys.stdout', new_callable=Mock())
     @patch("sys.exit")
     def test_list_testcases_json(self, mock_exit, _mock_stdout, mock_list):
-        fake_args = ["opentmi", "list", "--testcases", "--json"]
+        fake_args = ["opentmi", "--token", FAKE_TOKEN, "list", "--testcases", "--json"]
         with patch('sys.argv', fake_args):
             opentmiclient_main()
         mock_exit.assert_called_with(0)
@@ -84,7 +85,7 @@ class TestCli(unittest.TestCase):
     @patch('sys.stdout', new_callable=Mock())
     @patch("sys.exit")
     def test_list_results_json(self, mock_exit, _mock_stdout, mock_list):
-        fake_args = ["opentmi", "list", "--campaigns", "--json"]
+        fake_args = ["opentmi", "--token", FAKE_TOKEN, "list", "--campaigns", "--json"]
         with patch('sys.argv', fake_args):
             opentmiclient_main()
         mock_exit.assert_called_with(0)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,6 +1,5 @@
-import sys
 import unittest
-from mock import MagicMock, patch, call, Mock
+from mock import patch, Mock
 from opentmi_client.cli.main import opentmiclient_main, OpentTMIClientCLI
 
 

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -1,7 +1,8 @@
 # pylint: disable=missing-docstring
 
 import unittest
-from logging import Logger
+from logging import Logger, DEBUG
+from opentmi_client import OpenTmiClient
 from opentmi_client.utils import get_logger
 
 class TestLogger(unittest.TestCase):
@@ -14,6 +15,11 @@ class TestLogger(unittest.TestCase):
         logger = get_logger(name="new", level=None)
         self.assertIsInstance(logger, Logger)
         self.assertEqual(len(logger.handlers), 1)
+
+    def test_set_logger(self):
+        client = OpenTmiClient()
+        client.set_logger(get_logger(level=DEBUG))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -1,4 +1,5 @@
-import os
+# pylint: disable=missing-docstring
+
 import unittest
 from logging import Logger
 from opentmi_client.utils import get_logger

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from opentmi_client.utils import Query, Find, Distinct
 

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import unittest
 from opentmi_client.utils import Query, Find, Distinct
 

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import os
 import unittest
 from opentmi_client.utils import is_object_id, resolve_host, resolve_token, archive_files

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from opentmi_client.utils import is_object_id, resolve_host, archive_files
+from opentmi_client.utils import is_object_id, resolve_host, resolve_token, archive_files
 
 
 class TestTools(unittest.TestCase):
@@ -21,6 +21,12 @@ class TestTools(unittest.TestCase):
         self.assertEqual(resolve_host("https://mydomain"), "https://mydomain")
         self.assertEqual(resolve_host("https://1.2.3.4:3000"), "https://1.2.3.4:3000")
         self.assertEqual(resolve_host("https://1.2.3.4", 3000), "https://1.2.3.4:3000")
+        self.assertEqual(resolve_host("https://aa.bb.cc@1.2.3.4", 3000), "https://1.2.3.4:3000")
+
+    def test_resolve_token(self):
+        self.assertEqual(resolve_token("http://1.2.3.4"), None)
+        self.assertEqual(resolve_token("http://a.b.c@1.2.3.4"), "a.b.c")
+        self.assertEqual(resolve_token("https://aa.bb.cc@1.2.3.4"), "aa.bb.cc")
 
     def test_archive(self):
         zip = 'temp.zip'

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -21,7 +21,7 @@ class TestTools(unittest.TestCase):
         self.assertEqual(resolve_host("https://mydomain"), "https://mydomain")
         self.assertEqual(resolve_host("https://1.2.3.4:3000"), "https://1.2.3.4:3000")
         self.assertEqual(resolve_host("https://1.2.3.4", 3000), "https://1.2.3.4:3000")
-        self.assertEqual(resolve_host("https://aa.bb.cc@1.2.3.4", 3000), "https://1.2.3.4:3000")
+        self.assertEqual(resolve_host("https://1.2.3.4", 3000), "https://1.2.3.4:3000")
 
     def test_resolve_token(self):
         self.assertEqual(resolve_token("http://1.2.3.4"), None)

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,9 +1,25 @@
 # pylint: disable=missing-docstring
 
 import os
+import unittest.mock as mock
 import unittest
-from opentmi_client.utils import is_object_id, resolve_host, resolve_token, archive_files
+from opentmi_client.utils import is_object_id, resolve_host, resolve_token, archive_files, requires_logged_in
 
+
+class Test:
+    def __init__(self, logged_in):
+        self.logged_in = logged_in
+
+    @requires_logged_in
+    def api(self):
+        return True
+
+    def try_login(self, raise_if_fail):
+        return self
+
+    @property
+    def is_logged_in(self):
+        return self.logged_in
 
 class TestTools(unittest.TestCase):
     def test_is_object_id(self):
@@ -35,6 +51,18 @@ class TestTools(unittest.TestCase):
         archive_files(['test_tools.py'], zip, os.path.dirname(__file__))
         self.assertTrue(os.path.exists(zip))
         os.remove(zip)
+
+    def test_requires_logged_in(self):
+        test = Test(logged_in=True)
+        with mock.patch.object(test, 'try_login') as monkey:
+            self.assertTrue(test.api())
+            self.assertTrue(monkey.notCalled())
+
+        test = Test(logged_in=False)
+        with mock.patch.object(test, 'try_login') as monkey:
+            self.assertTrue(test.api())
+            self.assertTrue(monkey.calledOnceWith(raise_if_fail=True))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,8 +1,8 @@
 # pylint: disable=missing-docstring
 
 import os
-import unittest.mock as mock
 import unittest
+from mock import patch
 from opentmi_client.utils import is_object_id, resolve_host, resolve_token, archive_files, requires_logged_in
 
 
@@ -54,12 +54,12 @@ class TestTools(unittest.TestCase):
 
     def test_requires_logged_in(self):
         test = Test(logged_in=True)
-        with mock.patch.object(test, 'try_login') as monkey:
+        with patch.object(test, 'try_login') as monkey:
             self.assertTrue(test.api())
             self.assertTrue(monkey.notCalled())
 
         test = Test(logged_in=False)
-        with mock.patch.object(test, 'try_login') as monkey:
+        with patch.object(test, 'try_login') as monkey:
             self.assertTrue(test.api())
             self.assertTrue(monkey.calledOnceWith(raise_if_fail=True))
 

--- a/test/test_transport.py
+++ b/test/test_transport.py
@@ -45,15 +45,15 @@ class TestRequest(unittest.TestCase):
         HOST = "127.0.0.1"
         transport.set_host(HOST)
         self.assertEqual(transport.token, None)
-        self.assertEqual(transport.host, HOST)
+        self.assertEqual(transport.host, "http://"+HOST)
 
-        transport.set_host("a.b.c@"+HOST)
+        transport.set_host("http://a.b.c@"+HOST)
         self.assertEqual(transport.token, "a.b.c")
         self.assertEqual(transport.host, "http://"+HOST)
 
         transport.set_host("https://aa.bb.cc@"+HOST)
         self.assertEqual(transport.token, "aa.bb.cc")
-        self.assertEqual(transport.host, "http://"+HOST)
+        self.assertEqual(transport.host, "https://"+HOST)
 
     def test_get_json_not_found(self):
         transport = Transport()

--- a/test/test_transport.py
+++ b/test/test_transport.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import unittest
 from mock import patch
 from requests import Response, RequestException

--- a/test/test_transport.py
+++ b/test/test_transport.py
@@ -40,6 +40,21 @@ class TestRequest(unittest.TestCase):
         resp.status_code = 199
         self.assertFalse(Transport.is_success(resp))
 
+    def test_set_host(self):
+        transport = Transport()
+        HOST = "127.0.0.1"
+        transport.set_host(HOST)
+        self.assertEqual(transport.token, None)
+        self.assertEqual(transport.host, HOST)
+
+        transport.set_host("a.b.c@"+HOST)
+        self.assertEqual(transport.token, "a.b.c")
+        self.assertEqual(transport.host, "http://"+HOST)
+
+        transport.set_host("https://aa.bb.cc@"+HOST)
+        self.assertEqual(transport.token, "aa.bb.cc")
+        self.assertEqual(transport.host, "http://"+HOST)
+
     def test_get_json_not_found(self):
         transport = Transport()
         with self.assertRaises(TransportException):

--- a/test/test_transport.py
+++ b/test/test_transport.py
@@ -1,7 +1,6 @@
 import unittest
-from mock import patch, MagicMock
+from mock import patch
 from requests import Response, RequestException
-import requests
 from opentmi_client.transport import Transport
 from opentmi_client.utils.exceptions import TransportException
 


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
this PR improve login related logic and preparing for "require login" in future. API changes related only for constructor. Also brings more options to authenticate.

**Breaking changes:**
* dropped following parameters from constructor: `result_converter`, `testcase_converter`
those can be still used through APIs:  `set_result_converter()` and `set_testcase_converter` when needed..

Depends on https://github.com/OpenTMI/opentmi/pull/209

## Todos
- [x] Tests
- [x] Documentation

## Deploy Notes
Possible to use environment variables for login ->
Using username and password: `OPENTMI_USERNAME` and `OPENTMI_PASSWORD` or
Using github access token: `OPENTMI_GITHUB_ACCESS_TOKEN`.