### PR TITLE
add metadata key-value API for result.execution object

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,6 @@
 coverage
 coveralls
 mock
-pylint
+pylint==2.5.2
 Sphinx
 nose

--- a/examples/login_github_token.py
+++ b/examples/login_github_token.py
@@ -1,5 +1,5 @@
 from os import getenv
 from opentmi_client import OpenTmiClient
 
-client = OpenTmiClient(port=3000)
+client = OpenTmiClient(host=getenv('OPENTMI_HOST'))
 client.login_with_access_token(access_token=getenv('GITHUB_ACCESS_TOKEN'))

--- a/opentmi_client/api/result/Execution.py
+++ b/opentmi_client/api/result/Execution.py
@@ -10,6 +10,7 @@ from opentmi_client.api.result.Sut import Sut
 from opentmi_client.api.result.Dut import Dut
 
 
+# pylint: disable-msg=too-many-arguments too-many-instance-attributes
 class Execution(BaseApi):
     """
     Execution class,

--- a/opentmi_client/api/result/Execution.py
+++ b/opentmi_client/api/result/Execution.py
@@ -5,6 +5,7 @@ from opentmi_client.utils.Base import BaseApi
 from opentmi_client.utils.decorators import setter_rules
 from opentmi_client.api.result.File import File
 from opentmi_client.api.result.Environment import Environment
+from opentmi_client.api.result.Metadata import Metadata
 from opentmi_client.api.result.Sut import Sut
 from opentmi_client.api.result.Dut import Dut
 
@@ -18,7 +19,8 @@ class Execution(BaseApi):
                  verdict=None,
                  note=None,
                  duration=None,
-                 environment=None):
+                 environment=None,
+                 metadata=None):
         """
         Execution constructor
         :param verdict: String
@@ -33,10 +35,8 @@ class Execution(BaseApi):
             self.note = note
         if duration:
             self.duration = duration
-        if environment:
-            self.environment = environment
-        else:
-            self.environment = Environment()
+        self.environment = environment or Environment()
+        self.metadata = metadata or Metadata()
         self.sut = Sut()
 
     @property
@@ -152,6 +152,23 @@ class Execution(BaseApi):
         :param value: Environment
         """
         self.set("env", value)
+
+    @property
+    def metadata(self):
+        """
+        Getter for metadata
+        :return: Metadata
+        """
+        return self.get("metadata")
+
+    @metadata.setter
+    @setter_rules(value_type=Metadata)
+    def metadata(self, value):
+        """
+        Setter for metadata
+        :param value: Metadata
+        """
+        self.set("metadata", value)
 
     @property
     def sut(self):

--- a/opentmi_client/api/result/Metadata.py
+++ b/opentmi_client/api/result/Metadata.py
@@ -1,0 +1,23 @@
+"""
+OpenTMI module for Metadata details
+"""
+from opentmi_client.utils.Base import BaseApi
+
+
+class Metadata(BaseApi):
+    """
+    Environment class
+    """
+    def __init__(self):
+        """
+        constructor for Metadata
+        """
+        super(Metadata, self).__init__()
+
+    def append(self, key: str, value: str):
+        """
+        Setter for test case keywords
+        :param key: String
+        :param value: String
+        """
+        self.set(key, value)

--- a/opentmi_client/api/result/Metadata.py
+++ b/opentmi_client/api/result/Metadata.py
@@ -6,13 +6,8 @@ from opentmi_client.utils.Base import BaseApi
 
 class Metadata(BaseApi):
     """
-    Environment class
+    Metadata class
     """
-    def __init__(self):
-        """
-        constructor for Metadata
-        """
-        super(Metadata, self).__init__()
 
     def append(self, key: str, value: str):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests>=2.13.0
 jsonmerge
 six
 pydash
-junitparser
+junitparser<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests>=2.13.0
 jsonmerge
 six
 pydash
-junitparser<2.0.0
+junitparser==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests>=2.13.0
 jsonmerge
 six
 pydash
-junitparser==1.4.1
+junitparser<2.0.0

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(name='opentmi_client',
           "jsonmerge",
           "six",
           "pydash",
-          "junitparser"
+          "junitparser<2.0.0"
       ],
       classifiers=[
           "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(name='opentmi_client',
       tests_require=[
           "coverage",
           "mock",
-          "pylint",
+          "pylint==2.5.2",
           "Sphinx",
           "nose"
       ],

--- a/test/test_api_result.py
+++ b/test/test_api_result.py
@@ -25,6 +25,11 @@ class TestResult(unittest.TestCase):
         self.assertEqual(result.execution.note, 'notes')
         self.assertEqual(result.execution.duration, None)
 
+    def test_execution_metadata(self):
+        result = Result()
+        result.execution.metadata.append('key', 'value')
+        self.assertEqual(result.execution.metadata.get('key'), 'value')
+
     def test_dut(self):
         result = Result()
         dut = Dut()


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Add Result:execution.metadata object that holds key-value pairs.