### PR TITLE
restrict execute note to 1000 characters

### DIFF
--- a/opentmi_client/api/result/Execution.py
+++ b/opentmi_client/api/result/Execution.py
@@ -72,7 +72,6 @@ class Execution(BaseApi):
         API truncate long strings to 1000 first characters to avoid long crash logs storing to logs.
         :param value: String
         """
-        
         self.set("note", value[:1000])
 
     @property

--- a/opentmi_client/api/result/Execution.py
+++ b/opentmi_client/api/result/Execution.py
@@ -69,9 +69,11 @@ class Execution(BaseApi):
     def note(self, value):
         """
         Setter for test notes
+        API truncate long strings to 1000 first characters to avoid long crash logs storing to logs.
         :param value: String
         """
-        self.set("note", value)
+        
+        self.set("note", value[:1000])
 
     @property
     def duration(self):


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
just to avoid storing kB of crash logs. Another option could be to truncate in backend side or user side [here](https://github.com/OpenTMI/pytest-opentmi/blob/afe87a556ae88e634d3fe78db168041441e813df/pytest_opentmi/OpenTmiReport.py#L60).