### PR TITLE
update urllib3 requirement and update deprecations

### DIFF
--- a/opentmi_client/transport/HttpAdapter.py
+++ b/opentmi_client/transport/HttpAdapter.py
@@ -65,7 +65,7 @@ def create_http_session(base_url: str, logger: logging.Logger) -> requests.Sessi
         total=4,
         backoff_factor=2,
         status_forcelist=[429, 500, 502, 503, 504],
-        method_whitelist=["HEAD", "GET", "OPTIONS"],
+        allowed_methods=["HEAD", "GET", "OPTIONS"],
     )
     retry_adapter = TimeoutHTTPAdapter(max_retries=retry_strategy)
     session = requests.Session()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jsonmerge
 six
 pydash
 junitparser<2.0.0
+urllib3>=1.26.0,<2

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(name='opentmi_client',
       },
       install_requires=[
           "requests>=2.13.0",
+          "urllib3>=1.26.0,<2",
           "jsonmerge",
           "six",
           "pydash",


### PR DESCRIPTION
silent possible urllib3.util.retry deprecated api warning


> Previously this parameter was named method_whitelist, that usage is deprecated in v1.26.0 and will be removed in v2.0.